### PR TITLE
Fix: 修复频道数据模型

### DIFF
--- a/nonebot/adapters/qq/models/guild.py
+++ b/nonebot/adapters/qq/models/guild.py
@@ -73,8 +73,8 @@ class Channel(BaseModel):
     position: int
     parent_id: Optional[str] = None
     owner_id: Optional[str] = None
-    private_type: Union[PrivateType, int]
-    speak_permission: Union[SpeakPermission, int]
+    private_type: Union[PrivateType, int, None] = None
+    speak_permission: Union[SpeakPermission, int, None] = None
     application_id: Optional[str] = None
     permissions: Optional[int] = None
 

--- a/nonebot/adapters/qq/models/guild.py
+++ b/nonebot/adapters/qq/models/guild.py
@@ -73,8 +73,8 @@ class Channel(BaseModel):
     position: int
     parent_id: Optional[str] = None
     owner_id: Optional[str] = None
-    private_type: Union[PrivateType, int, None] = None
-    speak_permission: Union[SpeakPermission, int, None] = None
+    private_type: Optional[Union[PrivateType, int]] = None
+    speak_permission: Optional[Union[SpeakPermission, int]] = None
     application_id: Optional[str] = None
     permissions: Optional[int] = None
 

--- a/nonebot/adapters/qq/permission.py
+++ b/nonebot/adapters/qq/permission.py
@@ -8,15 +8,15 @@ from .event import MessageCreateEvent, AtMessageCreateEvent
 async def _guild_channel_admin(
     event: Union[AtMessageCreateEvent, MessageCreateEvent]
 ) -> bool:
-    return 5 in getattr(event.member, "roles", ())
+    return "5" in getattr(event.member, "roles", ())
 
 
 async def _guild_admin(event: Union[AtMessageCreateEvent, MessageCreateEvent]) -> bool:
-    return 2 in getattr(event.member, "roles", ())
+    return "2" in getattr(event.member, "roles", ())
 
 
 async def _guild_owner(event: Union[AtMessageCreateEvent, MessageCreateEvent]) -> bool:
-    return 4 in getattr(event.member, "roles", ())
+    return "4" in getattr(event.member, "roles", ())
 
 
 GUILD_CHANNEL_ADMIN: Permission = Permission(_guild_channel_admin)


### PR DESCRIPTION
- 修复频道权限类型：#55 中将 `role` 的类型修改为 `str`，权限处理需同步修改。
- 修复子频道字段：获取子频道列表 API 中会返回子频道分组项，子频道分组项数据中不存在 `private_type` 和 `speak_permission` 字段。