### PR TITLE
Feature: 为 MessageSegment 添加 add 操作类型推导支持

### DIFF
--- a/nonebot/adapters/qq/message.py
+++ b/nonebot/adapters/qq/message.py
@@ -107,6 +107,22 @@ class MessageSegment(BaseMessageSegment["Message"]):
         )
 
     @override
+    def __add__(
+        self, other: Union[str, "MessageSegment", Iterable["MessageSegment"]]
+    ) -> "Message":
+        return Message(self) + (
+            MessageSegment.text(other) if isinstance(other, str) else other
+        )
+
+    @override
+    def __radd__(
+        self, other: Union[str, "MessageSegment", Iterable["MessageSegment"]]
+    ) -> "Message":
+        return (
+            MessageSegment.text(other) if isinstance(other, str) else Message(other)
+        ) + self
+
+    @override
     def is_text(self) -> bool:
         return self.type == "text"
 


### PR DESCRIPTION
当前对适配器的 `MessageSegment` 进行 add 操作时，类型推导会直接使用 `nonebot.adapters` 导出的 `MessageSegment` 中的以下方法：

```python
def __add__(self: TMS, other: Union[str, TMS, Iterable[TMS]]) -> TM:
```

在操作数类型不同时，如 `MessageSegment.text("abc") + MessageSegment.emoji("5")`，会被解释为：

```python
def __add__(self: Text, other: Union[str, Text, Iterable[Text]]) -> Text:
```

无法接受右侧 `Emoji` 类型的操作数。