### PR TITLE
Fix: 修复群语音和视频消息类型错误

### DIFF
--- a/nonebot/adapters/qq/bot.py
+++ b/nonebot/adapters/qq/bot.py
@@ -313,12 +313,12 @@ class Bot(BaseBot):
         if image := message["image"]:
             kwargs["file_type"] = 1
             kwargs["url"] = image[-1].data["url"]
-        elif audio := message["audio"]:
-            kwargs["file_type"] = 2
-            kwargs["url"] = audio[-1].data["url"]
         elif video := message["video"]:
-            kwargs["file_type"] = 3
+            kwargs["file_type"] = 2
             kwargs["url"] = video[-1].data["url"]
+        elif audio := message["audio"]:
+            kwargs["file_type"] = 3
+            kwargs["url"] = audio[-1].data["url"]
         elif file := message["file"]:
             kwargs["file_type"] = 4
             kwargs["url"] = file[-1].data["url"]


### PR DESCRIPTION
Fixes #88 

根据 [富媒体消息 | QQ机器人文档](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/send-receive/rich-media.html#%E7%94%A8%E4%BA%8E%E7%BE%A4%E8%81%8A) 中的 `file_type`的说明
> 媒体类型：1 图片，2 视频，3 语音，4 文件（暂不开放）

应设置视频的`file_type`为`2`，语音的`file_type`为`3`