### PR TITLE
Revert "Feature: 全量群消息事件, 无需@机器人"

### DIFF
--- a/nonebot/adapters/qq/bot.py
+++ b/nonebot/adapters/qq/bot.py
@@ -139,19 +139,11 @@ def _check_at_me(
     ):
         event.to_me = True
 
-    if (
-        isinstance(event, QQMessageEvent)
-        and event.mentions is not None
-        and any(user.is_you for user in event.mentions)
-    ):
-        event.to_me = True
-
     def _is_at_me_seg(segment: MessageSegment) -> bool:
-        if segment.type == "mention_user":
-            return segment.data.get("user_id") == bot.self_info.id
-        if segment.type == "group_mention_user":
-            return segment.data.get("is_you", False)
-        return False
+        return (
+            segment.type == "mention_user"
+            and segment.data.get("user_id") == bot.self_info.id
+        )
 
     message = event.get_message()
 

--- a/nonebot/adapters/qq/event.py
+++ b/nonebot/adapters/qq/event.py
@@ -80,9 +80,6 @@ class EventType(str, Enum):
     C2C_MESSAGE_CREATE = "C2C_MESSAGE_CREATE"
     GROUP_AT_MESSAGE_CREATE = "GROUP_AT_MESSAGE_CREATE"
 
-    # C2C_GROUP_MESSAGE
-    GROUP_MESSAGE_CREATE = "GROUP_MESSAGE_CREATE"
-
     # INTERACTION
     INTERACTION_CREATE = "INTERACTION_CREATE"
 
@@ -392,12 +389,12 @@ class C2CMessageCreateEvent(QQMessageEvent):
 
 
 @register_event_class
-class GroupMessageCreateEvent(QQMessageEvent):
-    __type__ = EventType.GROUP_MESSAGE_CREATE
+class GroupAtMessageCreateEvent(QQMessageEvent):
+    __type__ = EventType.GROUP_AT_MESSAGE_CREATE
 
     author: GroupMemberAuthor
     group_openid: str
-    group_id: str
+    to_me: bool = True
 
     @override
     def get_message(self) -> Message:
@@ -424,13 +421,6 @@ class GroupMessageCreateEvent(QQMessageEvent):
             f"{self.author.member_openid}@[Group:{self.group_openid}]: "
             f"{self.get_message()!r}"
         )
-
-
-@register_event_class
-class GroupAtMessageCreateEvent(GroupMessageCreateEvent):
-    __type__ = EventType.GROUP_AT_MESSAGE_CREATE
-
-    to_me: bool = True
 
 
 @register_event_class

--- a/nonebot/adapters/qq/message.py
+++ b/nonebot/adapters/qq/message.py
@@ -12,7 +12,6 @@ from nonebot.adapters import Message as BaseMessage
 from nonebot.adapters import MessageSegment as BaseMessageSegment
 
 from .models import Attachment as QQAttachment
-from .models import GroupMentionUser as QQGroupMentionUser
 from .models import Message as GuildMessage
 from .models import (
     MessageActionButton,
@@ -283,40 +282,6 @@ class Emoji(MessageSegment):
         return f"<emoji:{self.data['id']}>"
 
 
-class _GroupMentionUserData(TypedDict):
-    bot: bool
-    id: str
-    is_you: bool
-    member_openid: str
-    scope: str
-    username: str
-
-
-@dataclass
-class GroupMentionUser(MessageSegment):
-    if TYPE_CHECKING:
-        data: _GroupMentionUserData
-
-    @override
-    def __str__(self) -> str:
-        return f"<@{self.data['id']}>"
-
-    @classmethod
-    @override
-    def _validate(cls, value) -> Self:
-        instance = super()._validate(value)
-        mention_user = type_validate_python(QQGroupMentionUser, instance.data)
-        instance.data = {
-            "bot": mention_user.bot,
-            "id": mention_user.id,
-            "is_you": mention_user.is_you,
-            "member_openid": mention_user.member_openid,
-            "scope": mention_user.scope,
-            "username": mention_user.username,
-        }
-        return instance
-
-
 class _MentionUserData(TypedDict):
     user_id: str
 
@@ -524,7 +489,6 @@ SEGMENT_TYPE_MAP: dict[str, type[MessageSegment]] = {
     "mention_user": MentionUser,
     "mention_channel": MentionChannel,
     "mention_everyone": MentionEveryone,
-    "group_mention_user": GroupMentionUser,
     "image": Attachment,
     "file_image": LocalAttachment,
     "audio": Attachment,
@@ -662,21 +626,6 @@ class Message(BaseMessage[MessageSegment]):
                 )
                 for seg in message.attachments
                 if seg.url
-            )
-        if message.mentions:
-            msg.extend(
-                GroupMentionUser(
-                    "group_mention_user",
-                    data={
-                        "bot": mention.bot,
-                        "id": mention.id,
-                        "is_you": mention.is_you,
-                        "member_openid": mention.member_openid,
-                        "scope": mention.scope,
-                        "username": mention.username,
-                    },
-                )
-                for mention in message.mentions
             )
         return msg
 

--- a/nonebot/adapters/qq/models/qq.py
+++ b/nonebot/adapters/qq/models/qq.py
@@ -20,15 +20,6 @@ class GroupMemberAuthor(BaseModel):
     username: str | None = None
 
 
-class GroupMentionUser(BaseModel):
-    bot: bool
-    id: str
-    is_you: bool
-    member_openid: str
-    scope: str
-    username: str
-
-
 class Attachment(BaseModel):
     content_type: str
     filename: str | None = None
@@ -52,7 +43,6 @@ class QQMessage(BaseModel):
     id: str
     content: str
     timestamp: str
-    mentions: list[GroupMentionUser] | None = None
     attachments: list[Attachment] | None = None
 
 
@@ -168,7 +158,6 @@ __all__ = [
     "FriendAuthor",
     "GroupMember",
     "GroupMemberAuthor",
-    "GroupMentionUser",
     "Media",
     "MessageActionButton",
     "MessagePromptKeyboard",


### PR DESCRIPTION
Reverts nonebot/adapter-qq#195

不是，凭什么 `group_mention_user` 要作为消息段去处理？你官Q能用这种结构发送 at？