### PR TITLE
Feature: 支持自定义 QQ WebSocket Gateway URL

### DIFF
--- a/nonebot/adapters/qq/adapter.py
+++ b/nonebot/adapters/qq/adapter.py
@@ -152,6 +152,8 @@ class Adapter(BaseAdapter):
         try:
             gateway_info = await bot.shard_url_get()
             ws_url = URL(gateway_info.url)
+            if self.qq_config.qq_custom_gateway_url:
+                ws_url = URL(self.qq_config.qq_custom_gateway_url)
         except Exception as e:
             log(
                 "ERROR",

--- a/nonebot/adapters/qq/adapter.py
+++ b/nonebot/adapters/qq/adapter.py
@@ -153,7 +153,7 @@ class Adapter(BaseAdapter):
             gateway_info = await bot.shard_url_get()
             ws_url = URL(gateway_info.url)
             if self.qq_config.qq_custom_gateway_url:
-                ws_url = URL(self.qq_config.qq_custom_gateway_url)
+                ws_url = self.qq_config.qq_custom_gateway_url
         except Exception as e:
             log(
                 "ERROR",

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from nonebot.compat import PYDANTIC_V2, ConfigDict
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -58,3 +60,5 @@ class Config(BaseModel):
     qq_auth_base: HttpUrl = Field("https://bots.qq.com/app/getAppAccessToken")  # type: ignore
     qq_verify_webhook: bool = True
     qq_bots: list[BotInfo] = Field(default_factory=list)
+
+    qq_custom_gateway_url: Optional[str] = None

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from nonebot.compat import PYDANTIC_V2, ConfigDict
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -61,4 +59,4 @@ class Config(BaseModel):
     qq_verify_webhook: bool = True
     qq_bots: list[BotInfo] = Field(default_factory=list)
 
-    qq_custom_gateway_url: Optional[str] = None
+    qq_custom_gateway_url: str | None = None

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -1,5 +1,5 @@
 from nonebot.compat import PYDANTIC_V2, ConfigDict
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl, field_validator
 
 
 class Intents(BaseModel):
@@ -60,3 +60,19 @@ class Config(BaseModel):
     qq_bots: list[BotInfo] = Field(default_factory=list)
 
     qq_custom_gateway_url: str | None = None
+
+    @field_validator("qq_custom_gateway_url")
+    @classmethod
+    def validate_gateway_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        from yarl import URL
+
+        url = URL(v)
+        if url.scheme not in ("ws", "wss"):
+            raise ValueError(
+                f"Gateway URL scheme must be ws:// or wss://, got {url.scheme}://"
+            )
+        if not url.host:
+            raise ValueError("Gateway URL must have a valid host")
+        return v

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -1,5 +1,6 @@
-from nonebot.compat import PYDANTIC_V2, ConfigDict
-from pydantic import BaseModel, Field, HttpUrl, field_validator
+from nonebot.compat import PYDANTIC_V2, ConfigDict, field_validator
+from pydantic import BaseModel, Field, HttpUrl
+from yarl import URL
 
 
 class Intents(BaseModel):
@@ -59,20 +60,18 @@ class Config(BaseModel):
     qq_verify_webhook: bool = True
     qq_bots: list[BotInfo] = Field(default_factory=list)
 
-    qq_custom_gateway_url: str | None = None
+    qq_custom_gateway_url: URL | None = None
 
-    @field_validator("qq_custom_gateway_url")
+    @field_validator("qq_custom_gateway_url", mode="before")
     @classmethod
-    def validate_gateway_url(cls, v: str | None) -> str | None:
+    def validate_gateway_url(cls, v: str | URL | None) -> URL | None:
         if v is None:
             return v
-        from yarl import URL
-
-        url = URL(v)
+        url = URL(v) if isinstance(v, str) else v
         if url.scheme not in ("ws", "wss"):
             raise ValueError(
                 f"Gateway URL scheme must be ws:// or wss://, got {url.scheme}://"
             )
         if not url.host:
             raise ValueError("Gateway URL must have a valid host")
-        return v
+        return url

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -71,7 +71,7 @@ class Config(BaseModel):
             return v
         url = URL(v) if isinstance(v, str) else v
         if not isinstance(url, URL):
-            raise TypeError(f"Invalid gateway url type")
+            raise TypeError("Invalid gateway url type")
         if url.scheme not in ("ws", "wss"):
             raise ValueError(
                 f"Gateway URL scheme must be ws:// or wss://, got {url.scheme}://"

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from nonebot.compat import PYDANTIC_V2, ConfigDict, field_validator
 from pydantic import BaseModel, Field, HttpUrl
 from yarl import URL
@@ -64,10 +66,12 @@ class Config(BaseModel):
 
     @field_validator("qq_custom_gateway_url", mode="before")
     @classmethod
-    def validate_gateway_url(cls, v: str | URL | None) -> URL | None:
+    def validate_gateway_url(cls, v: Any) -> URL | None:
         if v is None:
             return v
         url = URL(v) if isinstance(v, str) else v
+        if not isinstance(url, URL):
+            raise TypeError(f"Invalid gateway url type")
         if url.scheme not in ("ws", "wss"):
             raise ValueError(
                 f"Gateway URL scheme must be ws:// or wss://, got {url.scheme}://"


### PR DESCRIPTION
## 改动说明

新增可选配置项 `qq_custom_gateway_url`，允许用户覆写 QQ WebSocket Gateway 连接地址。

### 改动内容

- `config.py`: 新增 `qq_custom_gateway_url: Optional[str] = None` 配置字段
- `adapter.py`: 在 `run_bot_websocket` 中，获取官方 gateway URL 后，若配置了自定义 URL 则覆盖

### 适用场景

- **代理连接**: 通过代理服务器连接 QQ WebSocket
- **测试环境**: 连接测试/沙盒 gateway
- **自建服务**: 使用自建的 gateway 中转服务

### 配置示例

```dotenv
QQ_CUSTOM_GATEWAY_URL=wss://your-gateway.example.com
```

### 兼容性

- 完全向后兼容
- 默认值为 `None`，不改变任何现有行为
- 仅在显式配置时生效