### PR TITLE
Feature: 用户进退群事件 intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Intent 仅对 WebSocket 连接方式生效。以下为所有 Intent 配置项以
   "direct_message": false,
   "open_forum_event": false,
   "audio_live_member": false,
+  "group_members": true,
   "c2c_group_at_messages": false,
   "interaction": false,
   "message_audit": true,

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ QQ_BOTS='
     "secret": "xxx",
     "intent": {
       "c2c_group_at_messages": true,
-      "group_members": false
+      "group_members": true
     },
     "use_websocket": false
   }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Intent 仅对 WebSocket 连接方式生效。以下为所有 Intent 配置项以
   "direct_message": false,
   "open_forum_event": false,
   "audio_live_member": false,
-  "group_members": true,
+  "group_members": false,
   "c2c_group_at_messages": false,
   "interaction": false,
   "message_audit": true,

--- a/README.md
+++ b/README.md
@@ -49,21 +49,35 @@ QQ_IS_SANDBOX=true
 
 Intent 仅对 WebSocket 连接方式生效。以下为所有 Intent 配置项以及默认值：
 
-```json
+```jsonc
 {
+  // 频道事件
   "guilds": true,
+  // 频道成员事件
   "guild_members": true,
+  // 频道消息事件
   "guild_messages": false,
+  // 频道消息表态事件
   "guild_message_reactions": true,
+  // 频道私信事件
   "direct_message": false,
+  // 频道公域论坛事件
   "open_forum_event": false,
+  // 频道音频或直播成员事件
   "audio_live_member": false,
+  // 群成员变更事件
   "group_members": false,
+  // 私聊与群聊消息事件
   "c2c_group_at_messages": false,
+  // 互动事件
   "interaction": false,
+  // 频道消息审核事件
   "message_audit": true,
+  // 频道私域论坛事件
   "forum_event": false,
+  // 频道音频操作事件
   "audio_action": false,
+  // 频道@机器人消息事件
   "at_messages": true
 }
 ```
@@ -99,7 +113,8 @@ QQ_BOTS='
     "token": "xxx",
     "secret": "xxx",
     "intent": {
-      "c2c_group_at_messages": true
+      "c2c_group_at_messages": true,
+      "group_members": false
     },
     "use_websocket": false
   }

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -13,7 +13,7 @@ class Intents(BaseModel):
     direct_message: bool = False
     open_forum_event: bool = False
     audio_live_member: bool = False
-    group_members: bool = True
+    group_members: bool = False
     c2c_group_at_messages: bool = False
     interaction: bool = False
     message_audit: bool = True

--- a/nonebot/adapters/qq/config.py
+++ b/nonebot/adapters/qq/config.py
@@ -13,6 +13,7 @@ class Intents(BaseModel):
     direct_message: bool = False
     open_forum_event: bool = False
     audio_live_member: bool = False
+    group_members: bool = True
     c2c_group_at_messages: bool = False
     interaction: bool = False
     message_audit: bool = True
@@ -36,6 +37,7 @@ class Intents(BaseModel):
             | self.direct_message << 12
             | self.open_forum_event << 18
             | self.audio_live_member << 19
+            | self.group_members << 24
             | self.c2c_group_at_messages << 25
             | self.interaction << 26
             | self.message_audit << 27


### PR DESCRIPTION
#206

试了可以正常收到事件，可能是ws的也上线或者灰度了

```shell
06-28 17:50:37 [SUCCESS] nonebot | QQ xxx | [EventType.GROUP_MEMBER_REMOVE]: {'event_id': 'GROUP_MEMBER_REMOVE:xxx', 'timestamp': datetime.datetime(2026, 6, 28, 9, 50, 34, tzinfo=TzInfo(0)), 'group_openid': 'xxx', 'member_openid': 'xxx'}

06-28 17:50:49 [SUCCESS] nonebot | QQ xxx | [EventType.GROUP_MEMBER_ADD]: {'event_id': 'GROUP_MEMBER_ADD:xxx', 'timestamp': datetime.datetime(2026, 6, 28, 9, 50, 46, tzinfo=TzInfo(0)), 'group_openid': 'xxx', 'member_openid': 'xxx'}
```