### PR TITLE
fix: send() 缺少 GroupMemberRemoveEvent 的路由分支

### DIFF
--- a/nonebot/adapters/qq/bot.py
+++ b/nonebot/adapters/qq/bot.py
@@ -30,7 +30,7 @@ from .event import (
     FriendAddEvent,
     GroupAddRobotEvent,
     GroupAtMessageCreateEvent,
-    GroupMemberAddEvent,
+    GroupMemberEvent,
     GroupMessageCreateEvent,
     GuildMessageEvent,
     InteractionCreateEvent,
@@ -733,7 +733,8 @@ class Bot(BaseBot):
             return await self.send_to_c2c(
                 openid=event.get_user_id(), message=message, event_id=event.event_id
             )
-        elif isinstance(event, GroupMemberAddEvent):
+        elif isinstance(event, GroupMemberEvent):
+            # 覆盖 GroupMemberAddEvent/GroupMemberRemoveEvent，两者路由方式相同。
             return await self.send_to_group(
                 group_openid=event.group_openid,
                 message=message,


### PR DESCRIPTION
之前只处理了 GroupMemberAddEvent，成员退群时被动回复直接落到
"Event cannot be replied to!" 的兜底异常。两者都继承自
GroupMemberEvent 且路由方式完全一致，改成按基类判断。