### PR TITLE
fix: QQReplyMessage.message_type/msg_idx 应可空

### DIFF
--- a/nonebot/adapters/qq/models/qq.py
+++ b/nonebot/adapters/qq/models/qq.py
@@ -77,8 +77,8 @@ class _ReplyAuthor(BaseModel):
 class QQReplyMessage(BaseModel):
     content: str
     attachments: list[Attachment] | None = None
-    message_type: int
-    msg_idx: str
+    message_type: int | None = None
+    msg_idx: str | None = None
     author: _ReplyAuthor | None = None
 
 


### PR DESCRIPTION
Closes #217

回复一条本身带有多层嵌套引用链的消息时，生成的 `msg_elements` 条目仅为合成的摘要大文本块（只有内容，缺少 `message_type`、`msg_idx` 字段）。
Pydantic 校验抛出两个字段的“字段必填”错误，事件解析静默失败。该错误被 `dispatch_event` 内部的 try‑except 捕获，因此不会造成进程崩溃，但该消息永远不会投递到任何业务处理器。
已对照生产报错堆栈里的原始异常载荷完成验证：此前会抛出 `ValidationError`；现在当 `message_type=None`、`msg_idx=None` 时可以正常解析。已确认普通正常场景（两个字段均存在）不受改动影响。